### PR TITLE
fix: 결제 완료 이벤트 발행 및 실행 로직 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^3.2.2",
         "@nestjs/core": "^9.0.0",
+        "@nestjs/event-emitter": "^2.0.4",
         "@nestjs/platform-express": "^9.0.0",
         "@prisma/client": "^5.12.1",
         "dotenv": "^16.4.5",
@@ -1795,6 +1796,18 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-2.0.4.tgz",
+      "integrity": "sha512-quMiw8yOwoSul0pp3mOonGz8EyXWHSBTqBy8B0TbYYgpnG1Ix2wGUnuTksLWaaBiiOTDhciaZ41Y5fJZsSJE1Q==",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -4187,6 +4200,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -10021,6 +10039,14 @@
         "uid": "2.0.2"
       }
     },
+    "@nestjs/event-emitter": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-2.0.4.tgz",
+      "integrity": "sha512-quMiw8yOwoSul0pp3mOonGz8EyXWHSBTqBy8B0TbYYgpnG1Ix2wGUnuTksLWaaBiiOTDhciaZ41Y5fJZsSJE1Q==",
+      "requires": {
+        "eventemitter2": "6.4.9"
+      }
+    },
     "@nestjs/platform-express": {
       "version": "9.4.3",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.4.3.tgz",
@@ -11825,6 +11851,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/event-emitter": "^2.0.4",
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "^5.12.1",
     "dotenv": "^16.4.5",

--- a/src/api/payment/payment.module.ts
+++ b/src/api/payment/payment.module.ts
@@ -18,7 +18,7 @@ import { IConcertDetailsReaderToken } from '../../domain/reservations/repositori
 import { ConcertDetailsReaderRepository } from '../../infrastructure/persistence/reservation/concert-details-reader.repository';
 import { IReservationWriteToken } from '../../domain/reservations/repositories/reservation-write.interface';
 import { ReservationWriteRepository } from '../../infrastructure/persistence/reservation/reservation-write.repository';
-import { DataplatformService } from 'src/infrastructure/external/dataplatform/dataplatform.service';
+import { PaymentEventPublisher } from '../../domain/events/application/publisher/payment-event-publisher.service';
 
 @Module({
   controllers: [PaymentController],
@@ -29,7 +29,7 @@ import { DataplatformService } from 'src/infrastructure/external/dataplatform/da
     PaymentValidationService,
     PointService,
     ReservationService,
-    DataplatformService,
+    PaymentEventPublisher,
     {
       provide: IReservationWriteToken,
       useClass: ReservationWriteRepository,

--- a/src/api/payment/usecase/create-payment.usecase.ts
+++ b/src/api/payment/usecase/create-payment.usecase.ts
@@ -3,8 +3,8 @@ import { PaymentValidationService } from '../../../domain/reservations/applicati
 import { PointService } from '../../../domain/points/application/point.service';
 import { OrderService } from '../../../domain/payment/application/order.service';
 import { ReservationService } from '../../../domain/reservations/application/reservation.service';
-import { DataplatformService } from '../../../infrastructure/external/dataplatform/dataplatform.service';
 import { PrismaService } from '../../../database/prisma/prisma.service';
+import { PaymentEventPublisher } from '../../../domain/events/application/publisher/payment-event-publisher.service';
 
 @Injectable()
 export class CreatePaymentUsecase {
@@ -13,18 +13,17 @@ export class CreatePaymentUsecase {
     private readonly pointService: PointService,
     private readonly orderService: OrderService,
     private readonly reservationService: ReservationService,
-    private readonly dataplatformService: DataplatformService,
+    private readonly paymentEventPublisher: PaymentEventPublisher,
     private readonly prisma: PrismaService,
   ) {}
 
   async execute(reservationId: number) {
-    const reservation =
-      await this.paymentValidationService.validateReservationForPayment(
-        reservationId,
-      );
-
     const { order, seatDetails } = await this.prisma.$transaction(
       async (tx) => {
+        const reservation =
+          await this.paymentValidationService.validateReservationForPayment(
+            reservationId,
+          );
         const userId = reservation.userId;
         const price = reservation.price;
         await this.pointService.subtractPoints(userId, price, tx);
@@ -35,17 +34,22 @@ export class CreatePaymentUsecase {
           tx,
         );
 
+        await this.reservationService.updateReservationStatus(
+          reservationId,
+          'confirmed',
+          tx,
+        );
+
         const order = await this.orderService.createOrder(
           userId,
           reservationId,
           price,
           tx,
         );
-
-        await this.dataplatformService.sendPaymentData(order, seatDetails);
         return { order, seatDetails };
       },
     );
+    this.paymentEventPublisher.success(order, seatDetails);
     return order;
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { PointModule } from './api/points/point.module';
 import { PaymentModule } from './api/payment/payment.module';
 import { ConfigModule } from '@nestjs/config';
 import { DataplatformModule } from './infrastructure/external/dataplatform/dataplatform.module';
+import { EventsModule } from './domain/events/events.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 console.log('=>(app.module.ts:26) process.env.NODE_ENV', process.env.NODE_ENV);
 
@@ -17,6 +19,8 @@ console.log('=>(app.module.ts:26) process.env.NODE_ENV', process.env.NODE_ENV);
     PointModule,
     PaymentModule,
     DataplatformModule,
+    EventsModule,
+    EventEmitterModule.forRoot(),
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env.local',

--- a/src/domain/events/application/listener/payment-event-listener.service.ts
+++ b/src/domain/events/application/listener/payment-event-listener.service.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEventSafe } from '../../on-event-safe.decorator';
+import { Order } from '../../../payment/entities/order';
+import { SeatDetails } from '../../../reservations/entities/concert-event-details';
+import { PaymentSuccessEvent } from '../../entities/payment-success-event';
+
+export const dataplatformServiceInterfaceSymbol = Symbol(
+  'DataplatformServiceInterface',
+);
+
+export interface DataplatformServiceInterface {
+  sendPaymentData(event: PaymentSuccessEvent): Promise<boolean>;
+}
+
+@Injectable()
+export class PaymentEventListener {
+  constructor(
+    @Inject(dataplatformServiceInterfaceSymbol)
+    private readonly dataplatformService: DataplatformServiceInterface,
+  ) {}
+
+  @OnEventSafe('success')
+  async paymentSuccessHandler(order: Order, seatDetails: SeatDetails) {
+    await this.dataplatformService.sendPaymentData(
+      new PaymentSuccessEvent(
+        order.id,
+        order.userId,
+        order.totalPrice,
+        seatDetails.concertEventId,
+        seatDetails.id,
+      ),
+    );
+  }
+}

--- a/src/domain/events/application/publisher/payment-event-publisher.service.ts
+++ b/src/domain/events/application/publisher/payment-event-publisher.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Order } from '../../../payment/entities/order';
+import { SeatDetails } from '../../../reservations/entities/concert-event-details';
+
+@Injectable()
+export class PaymentEventPublisher {
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  async success(order: Order, seatDetails: SeatDetails) {
+    this.eventEmitter.emit('success', order, seatDetails);
+  }
+}

--- a/src/domain/events/entities/payment-success-event.ts
+++ b/src/domain/events/entities/payment-success-event.ts
@@ -1,0 +1,9 @@
+export class PaymentSuccessEvent {
+  constructor(
+    public readonly orderId: number,
+    public readonly userId: number,
+    public readonly totalPrice: number,
+    public readonly concertEventId: number,
+    public readonly seatId: number,
+  ) {}
+}

--- a/src/domain/events/events.module.ts
+++ b/src/domain/events/events.module.ts
@@ -1,0 +1,17 @@
+import {
+  dataplatformServiceInterfaceSymbol,
+  PaymentEventListener,
+} from './application/listener/payment-event-listener.service';
+import { Module } from '@nestjs/common';
+import { DataplatformService } from '../../infrastructure/external/dataplatform/dataplatform.service';
+
+@Module({
+  providers: [
+    PaymentEventListener,
+    {
+      provide: dataplatformServiceInterfaceSymbol,
+      useClass: DataplatformService,
+    },
+  ],
+})
+export class EventsModule {}

--- a/src/domain/events/on-event-safe.decorator.ts
+++ b/src/domain/events/on-event-safe.decorator.ts
@@ -1,0 +1,31 @@
+import { applyDecorators, Logger } from '@nestjs/common';
+import { OnEvent, OnEventType } from '@nestjs/event-emitter';
+import { OnEventOptions } from '@nestjs/event-emitter/dist/interfaces';
+
+function _OnEventSafe() {
+  return function (target: any, key: string, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+
+    const metaKeys = Reflect.getOwnMetadataKeys(descriptor.value);
+    const metas = metaKeys.map((key) => [
+      key,
+      Reflect.getMetadata(key, descriptor.value),
+    ]);
+
+    descriptor.value = async function (...args: any[]) {
+      try {
+        await originalMethod.call(this, ...args);
+      } catch (err) {
+        Logger.error(err, err.stack, 'OnEventSafe');
+      }
+    };
+    metas.forEach(([k, v]) => Reflect.defineMetadata(k, v, descriptor.value));
+  };
+}
+
+export function OnEventSafe(
+  event: OnEventType,
+  options?: OnEventOptions | undefined,
+) {
+  return applyDecorators(OnEvent(event, options), _OnEventSafe());
+}

--- a/src/domain/reservations/application/reservation.service.ts
+++ b/src/domain/reservations/application/reservation.service.ts
@@ -7,6 +7,7 @@ import { PrismaService } from '../../../database/prisma/prisma.service';
 import {
   getReservationExpirationDate,
   Reservation,
+  ReservationStatus,
 } from '../entities/reservation';
 import {
   IReservationWrite,
@@ -75,6 +76,18 @@ export class ReservationService {
         seatNumber: seat.seatNumber,
       };
     });
+  }
+
+  async updateReservationStatus(
+    reserviationId: number,
+    status: ReservationStatus,
+    tx?: PrismaTxType,
+  ) {
+    return this.reservationWriteRepository.updateReservationStatus(
+      reserviationId,
+      status,
+      tx,
+    );
   }
 
   async reserveSeat(seatId: number, concertEventId: number, userId: number) {

--- a/src/domain/reservations/repositories/reservation-write.interface.ts
+++ b/src/domain/reservations/repositories/reservation-write.interface.ts
@@ -20,4 +20,9 @@ export interface IReservationWrite {
     isPaid: boolean,
     tx?: PrismaTxType,
   ): Promise<SeatDetails>;
+  updateReservationStatus(
+    reservationId: number,
+    status: string,
+    tx?: PrismaTxType,
+  ): Promise<Reservation>;
 }

--- a/src/infrastructure/external/dataplatform/dataplatform.service.ts
+++ b/src/infrastructure/external/dataplatform/dataplatform.service.ts
@@ -1,18 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { Order } from 'src/domain/payment/entities/order';
-import { SeatDetails } from 'src/domain/reservations/entities/concert-event-details';
+import { PaymentSuccessEvent } from '../../../domain/events/entities/payment-success-event';
+import { DataplatformServiceInterface } from '../../../domain/events/application/listener/payment-event-listener.service';
 
 @Injectable()
-export class DataplatformService {
-  async sendPaymentData(order: Order, seatDetails: SeatDetails) {
-    const data = {
-      orderId: order.id,
-      userId: order.userId,
-      totalPrice: order.totalPrice,
-      concertEventId: seatDetails.concertEventId,
-      seatId: seatDetails.id,
-    };
-    console.log(data);
+export class DataplatformService implements DataplatformServiceInterface {
+  async sendPaymentData(
+    paymentSuccessEvent: PaymentSuccessEvent,
+  ): Promise<boolean> {
     // 데이터 플랫폼에 예약 결제 데이터 전송 mock api
     return new Promise((resolve) => {
       setTimeout(() => {

--- a/src/infrastructure/persistence/reservation/reservation-write.repository.ts
+++ b/src/infrastructure/persistence/reservation/reservation-write.repository.ts
@@ -3,7 +3,10 @@ import { IReservationWrite } from '../../../domain/reservations/repositories/res
 import { SeatDetails } from '../../../domain/reservations/entities/concert-event-details';
 import { PrismaTxType } from '../../../database/prisma/prisma.type';
 import { PrismaService } from '../../../database/prisma/prisma.service';
-import { Reservation } from '../../../domain/reservations/entities/reservation';
+import {
+  Reservation,
+  ReservationStatus,
+} from '../../../domain/reservations/entities/reservation';
 
 @Injectable()
 export class ReservationWriteRepository implements IReservationWrite {
@@ -32,6 +35,31 @@ export class ReservationWriteRepository implements IReservationWrite {
           price: updatedSeat.price,
           version: updatedSeat.version,
         };
+      });
+  }
+
+  async updateReservationStatus(
+    reservationId: number,
+    status: ReservationStatus,
+    tx?: PrismaTxType,
+  ): Promise<Reservation> {
+    return (tx ?? this.prisma).reservation
+      .update({
+        where: { id: reservationId },
+        data: {
+          status: status,
+        },
+      })
+      .then((updatedReservation) => {
+        return new Reservation(
+          updatedReservation.id,
+          updatedReservation.userId,
+          updatedReservation.concertEventId,
+          updatedReservation.seatId,
+          updatedReservation.price,
+          updatedReservation.expirationDate,
+          updatedReservation.status,
+        );
       });
   }
 

--- a/src/test/integration_test/payment.spec.ts
+++ b/src/test/integration_test/payment.spec.ts
@@ -18,7 +18,9 @@ import { IReservationWriteToken } from '../../domain/reservations/repositories/r
 import { ReservationWriteRepository } from '../../infrastructure/persistence/reservation/reservation-write.repository';
 import { ReservationService } from '../../domain/reservations/application/reservation.service';
 import { TestUtil } from './util';
-import { DataplatformService } from '../../infrastructure/external/dataplatform/dataplatform.service';
+import { PaymentEventPublisher } from '../../domain/events/application/publisher/payment-event-publisher.service';
+import { EventsModule } from '../../domain/events/events.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 describe('결제 usecase 테스트', () => {
   let createPaymentUsecase: CreatePaymentUsecase;
@@ -27,6 +29,7 @@ describe('결제 usecase 테스트', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot(), EventsModule],
       providers: [
         TestUtil,
         PrismaService,
@@ -35,7 +38,7 @@ describe('결제 usecase 테스트', () => {
         PaymentValidationService,
         PointService,
         ReservationService,
-        DataplatformService,
+        PaymentEventPublisher,
         {
           provide: IOrderRepositoryToken,
           useClass: OrderWriteRepository,

--- a/src/test/reservation/services/reservation.service.spec.ts
+++ b/src/test/reservation/services/reservation.service.spec.ts
@@ -25,6 +25,7 @@ describe('예약 관련 로직에 대한 단위 테스트', () => {
       reserveSeatWithVersion: jest.fn(),
       createReservation: jest.fn(),
       updateSeatPaidStatus: jest.fn(),
+      updateReservationStatus: jest.fn(),
     };
     prisma = new PrismaService();
     reservationService = new ReservationService(


### PR DESCRIPTION
기존 결제 요청에 포함되어 있던 주문정보전송에 대한 로직을 event를 사용하여 분리하고, 비동기적으로 작동할 수 있도록 수정하여 전송의 실패나 지연이 결제 로직에 전파되지 않도록 수정했습니다.